### PR TITLE
DNR: fix detection of regexp lookahead and lookbehind

### DIFF
--- a/packages/tsurlfilter/src/rules/declarative-converter/grouped-rules-converters/abstract-rule-converter.ts
+++ b/packages/tsurlfilter/src/rules/declarative-converter/grouped-rules-converters/abstract-rule-converter.ts
@@ -932,7 +932,7 @@ export abstract class DeclarativeRuleConverter {
 
         // Back reference, possessive and negative lookahead are not supported
         // See more: https://github.com/google/re2/wiki/Syntax
-        if (regexFilter?.match(/\\[1-9]|(?<!\\)\?|{\S+}/g)) {
+        if (regexFilter?.match(/\\[1-9]|\(\?<?(!|=)|{\S+}/g)) {
             const msg = `Invalid regex in the: "${networkRule.getText()}"`;
             return new UnsupportedRegexpError(
                 msg,

--- a/packages/tsurlfilter/test/rules/declarative-converter/declarative-converter.test.ts
+++ b/packages/tsurlfilter/test/rules/declarative-converter/declarative-converter.test.ts
@@ -65,6 +65,27 @@ describe('DeclarativeConverter', () => {
         });
     });
 
+    it('converts simple blocking regexp rule with ? quantifier', async () => {
+        const filter = createFilter(['/aaa?/']);
+        const { ruleSets: [ruleSet] } = await converter.convert(
+            [filter],
+        );
+        const { declarativeRules } = await ruleSet.serialize();
+
+        const ruleId = 1;
+
+        expect(declarativeRules).toHaveLength(1);
+        expect(declarativeRules[0]).toEqual({
+            id: ruleId,
+            action: { type: 'block' },
+            condition: {
+                regexFilter: '/aaa?/',
+                isUrlFilterCaseSensitive: false,
+            },
+            priority: 1,
+        });
+    });
+
     describe('respects badfilter rules', () => {
         it('applies $badfilter to one filter', async () => {
             const filter = createFilter([


### PR DESCRIPTION
The detection is incorrectly matching any regexp with `?` qualifier, eg:
```regexp
/baynote(-observer)?([0-9]+)\.js/
```