### PR TITLE
fix `package.json` exports map types

### DIFF
--- a/packages/agtree/package.json
+++ b/packages/agtree/package.json
@@ -27,6 +27,7 @@
     "types": "dist/agtree.d.ts",
     "exports": {
         ".": {
+            "types": "./dist/agtree.d.ts",
             "import": "./dist/agtree.esm.js",
             "require": "./dist/agtree.cjs"
         },

--- a/packages/tsurlfilter/package.json
+++ b/packages/tsurlfilter/package.json
@@ -12,6 +12,7 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/types/src/index.d.ts",
       "import": "./dist/es/index.js",
       "require": "./dist/tsurlfilter.umd.js"
     },


### PR DESCRIPTION
I was trying to adapt the `@adgaurd/tsurlfilter` package in one of my projects. I get the following warning in my IDE:

<img width="1028" alt="image" src="https://github.com/AdguardTeam/tsurlfilter/assets/40715044/b68dd90e-7727-4c42-90ce-3039cbd1f4af">

It turns out that the `types` field is missing in the `package.json`'s exports map. The PR fixes that.